### PR TITLE
Update mongo-c-driver repository location

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "mongo-c-driver"]
 	path = mongo-c-driver
-	url = git://github.com/mongodb/mongo-c-driver.git
+	url = git://github.com/mongodb/mongo-c-driver-legacy.git


### PR DESCRIPTION
It appears that the MongoDB project has moved
git://github.com/mongodb/mongo-c-driver.git to
git://github.com/mongodb/mongo-c-driver-legacy.git and replaced
git://github.com/mongodb/mongo-c-driver.git with a new repository for
the next generation of the driver.  Until support for this new driver is
implemented, point the submodule at the new repository location for the
old driver.

Signed-off-by: Kevin Locke klocke@quantpost.com
